### PR TITLE
Add Caddy server for dns registering

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,0 +1,23 @@
+{
+    # email to use on Let's Encrypt
+    email youremail@email.com
+
+    # Uncomment for debug
+    #acme_ca https://acme-staging-v02.api.letsencrypt.org/directory
+    #debug
+}
+
+# tenderduty v2 
+:8888 {
+    reverse_proxy tenderduty:8888
+}
+
+# prometheus metrics
+:28686 {
+    reverse_proxy tenderduty:28686
+}
+
+# how to setup with your website
+# tenderduty.mysite.com {
+#     reverse_proxy tenderduty:28686
+# }

--- a/example-docker-compose.yml
+++ b/example-docker-compose.yml
@@ -1,13 +1,21 @@
 # docker-compose example for tenderduty, copy this file to docker-compose.yml and edit to suit.
 version: '3.2'
-services:
 
-  v2:
+networks:
+  monitor-net:
+    driver: bridge
+
+volumes:
+  home:
+  caddy_data: {}
+
+services:
+  tenderduty:
     build: .
     command: ""
-    ports:
-      - "8888:8888" # Dashboard
-      - "28686:28686" # Prometheus exporter
+    expose:
+      - 8888   # Dashboard
+      - 28686 # Prometheus exporter
     volumes:
       - home:/var/lib/tenderduty
       - ./config.yml:/var/lib/tenderduty/config.yml
@@ -17,6 +25,19 @@ services:
         max-size: "20m"
         max-file: "10"
     restart: unless-stopped
+    networks:
+      - monitor-net
 
-volumes:
-  home:
+  caddy:
+    image: caddy:2.3.0
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"
+      - "8888:8888"
+    volumes:
+      - ./caddy:/etc/caddy
+      - caddy_data:/data
+    restart: unless-stopped
+    networks:
+      - monitor-net

--- a/example-docker-compose.yml
+++ b/example-docker-compose.yml
@@ -15,7 +15,7 @@ services:
     command: ""
     expose:
       - 8888   # Dashboard
-      - 28686 # Prometheus exporter
+      - 28686  # Prometheus exporter
     volumes:
       - home:/var/lib/tenderduty
       - ./config.yml:/var/lib/tenderduty/config.yml
@@ -35,6 +35,7 @@ services:
       - "443:443"
       - "443:443/udp"
       - "8888:8888"
+      - "28686:28686"
     volumes:
       - ./caddy:/etc/caddy
       - caddy_data:/data


### PR DESCRIPTION
This makes it so using `docker compose up` will automatically setup Caddy for if you want to connect it to your domain. Example: https://tenderduty.lavenderfive.com/

Of course, it'll be necessary to change the actual website example in the Caddyfile...

Signed-off-by: Dylan Schultz <hello@schultzie.dev>