### PR TITLE
Enable chain specific configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Usage of tenderduty:
     	configuration file to use (default "config.yml")
   -state string
     	file for storing state between restarts (default ".tenderduty-state.json")
+  -cc string
+    	directory containing additional chain specific configurations (default "chains.d")
 ```
 
 ## Installing
@@ -39,4 +41,29 @@ docker run --rm ghcr.io/blockpane/tenderduty:latest -example-config >config.yml
 # edit config.yml and add chains, notification methods etc.
 docker run -d --name tenderduty -p "8888:8888" -p "28686:28686" --restart unless-stopped -v $(pwd)/config.yml:/var/lib/tenderduty/config.yml ghcr.io/blockpane/tenderduty:latest
 docker logs -f --tail 20 tenderduty
+```
+
+
+## Split Configuration
+
+For validators with many chains, chain specific configuration may be split into additional files and placed into the directory "chains.d".
+
+This directory can be changed with the -cc option
+
+The user friendly chain label will be taken from the name of the file.  
+
+For example:
+
+```
+chains.d/Juno.yml -> Juno
+chains.d/Lum Network.yml -> Lum Network
+```
+
+Configuration inside chains.d/Network.yml will be the YAML contents without the chain label.
+
+For example start directly with:
+
+```
+chain_id: demo-1
+    valoper_address: demovaloper...
 ```

--- a/main.go
+++ b/main.go
@@ -4,19 +4,21 @@ import (
 	_ "embed"
 	"flag"
 	"fmt"
-	td2 "github.com/blockpane/tenderduty/v2/td2"
 	"log"
 	"os"
+
+	td2 "github.com/blockpane/tenderduty/v2/td2"
 )
 
 //go:embed example-config.yml
 var defaultConfig []byte
 
 func main() {
-	var configFile, stateFile string
+	var configFile, chainConfigDirectory, stateFile string
 	var dumpConfig bool
 	flag.StringVar(&configFile, "f", "config.yml", "configuration file to use")
 	flag.StringVar(&stateFile, "state", ".tenderduty-state.json", "file for storing state between restarts")
+	flag.StringVar(&chainConfigDirectory, "cc", "chains.d", "directory containing additional chain specific configurations")
 	flag.BoolVar(&dumpConfig, "example-config", false, "print the an example config.yml and exit")
 	flag.Parse()
 
@@ -25,7 +27,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	err := td2.Run(configFile, stateFile)
+	err := td2.Run(configFile, stateFile, chainConfigDirectory)
 	if err != nil {
 		log.Println(err.Error(), "... exiting.")
 	}

--- a/td2/run.go
+++ b/td2/run.go
@@ -3,19 +3,20 @@ package tenderduty
 import (
 	"encoding/json"
 	"fmt"
-	dash "github.com/blockpane/tenderduty/v2/td2/dashboard"
 	"log"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+
+	dash "github.com/blockpane/tenderduty/v2/td2/dashboard"
 )
 
 var td = &Config{}
 
-func Run(configFile, stateFile string) error {
+func Run(configFile, stateFile, chainConfigDirectory string) error {
 	var err error
-	td, err = loadConfig(configFile, stateFile)
+	td, err = loadConfig(configFile, stateFile, chainConfigDirectory)
 	if err != nil {
 		return err
 	}

--- a/td2/types.go
+++ b/td2/types.go
@@ -4,16 +4,20 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
-	dash "github.com/blockpane/tenderduty/v2/td2/dashboard"
-	"github.com/go-yaml/yaml"
-	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 	"io"
 	"net/url"
 	"os"
+	"path"
 	"regexp"
+	"strings"
 	"sync"
 	"time"
+
+	dash "github.com/blockpane/tenderduty/v2/td2/dashboard"
+	"github.com/go-yaml/yaml"
+	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 )
 
 const (
@@ -338,8 +342,33 @@ func validateConfig(c *Config) (fatal bool, problems []string) {
 	return
 }
 
+func loadChainConfig(yamlFile string) (*ChainConfig, error) {
+	//#nosec -- variable specified on command line
+	f, e := os.OpenFile(yamlFile, os.O_RDONLY, 0600)
+	if e != nil {
+		return nil, e
+	}
+	i, e := f.Stat()
+	if e != nil {
+		_ = f.Close()
+		return nil, e
+	}
+	b := make([]byte, int(i.Size()))
+	_, e = f.Read(b)
+	_ = f.Close()
+	if e != nil {
+		return nil, e
+	}
+	c := &ChainConfig{}
+	e = yaml.Unmarshal(b, c)
+	if e != nil {
+		return nil, e
+	}
+	return c, nil
+}
+
 // loadConfig creates a new Config from a file.
-func loadConfig(yamlFile, stateFile string) (*Config, error) {
+func loadConfig(yamlFile, stateFile, chainConfigDirectory string) (*Config, error) {
 
 	//#nosec -- variable specified on command line
 	f, e := os.OpenFile(yamlFile, os.O_RDONLY, 0600)
@@ -361,6 +390,42 @@ func loadConfig(yamlFile, stateFile string) (*Config, error) {
 	e = yaml.Unmarshal(b, c)
 	if e != nil {
 		return nil, e
+	}
+
+	// Load additional chain configuration files
+	chainConfigFiles, e := os.ReadDir(chainConfigDirectory)
+	if e != nil {
+		l("Failed to scan chainConfigDirectory", e)
+	}
+
+	for _, chainConfigFile := range chainConfigFiles {
+		if chainConfigFile.IsDir() {
+			l("Skipping Directory: ", chainConfigFile.Name())
+			continue
+		}
+		if !strings.HasSuffix(chainConfigFile.Name(), ".yml") {
+			l("Skipping non .yml file: ", chainConfigFile.Name())
+			continue
+		}
+		fmt.Println("Reading Chain Config File: ", chainConfigFile.Name())
+		chainConfig, e := loadChainConfig(path.Join(chainConfigDirectory, chainConfigFile.Name()))
+		if e != nil {
+			l(fmt.Sprintf("Failed to read %s", chainConfigFile), e)
+			return nil, e
+		}
+
+		chainName := strings.Split(chainConfigFile.Name(), ".")[0]
+
+		// Create map if it didnt exist in config.yml
+		if c.Chains == nil {
+			c.Chains = make(map[string]*ChainConfig)
+		}
+		c.Chains[chainName] = chainConfig
+		l(fmt.Sprintf("Added %s from ", chainName), chainConfigFile.Name())
+	}
+
+	if len(c.Chains) == 0 {
+		return nil, errors.New("No Chains Configured")
 	}
 
 	c.alertChan = make(chan *alertMsg)


### PR DESCRIPTION
Add ability to read chain configuration from chains.d (configurable with -cc)

```
chains.d/Juno.yml -> Juno
chains.d/Lum Network.yml -> Lum Network
```
Configuration inside chains.d/Network.yml will be the YAML contents without the chain label.

For example start directly with:

```
chain_id: demo-1
    valoper_address: demovaloper...
```

