### PR TITLE
feat: add dead man's switch for td app itself

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -79,6 +79,14 @@ chains:
 | `telegram.api_key` | API key ... talk to @BotFather. More setup info in the [telegram doc](telegram.md). |
 | `telegram.channel` | See the [telegram doc](telegram.md) for how to get this value.                      |
 
+## Health Check Settings
+
+| Config Setting          | Description                                                                         |
+|-------------------------|-------------------------------------------------------------------------------------|
+| `healthcheck.enabled`   | Send pings to determine if the monitor is running?                                  |
+| `healthcheck.ping_url`  | URL to send pings to.                                                               |
+| `healthcheck.ping_rate` | Rate in which pings are sent in seconds.                                            |
+
 ## Chain Specific Settings
 
 *This section can be repeated for monitoring multiple chains.*

--- a/example-config.yml
+++ b/example-config.yml
@@ -1,5 +1,4 @@
 ---
-
 # controls whether the dashboard is enabled.
 enable_dashboard: yes
 # What TCP port the dashboard will listen on. Only the port is controllable for now.
@@ -39,7 +38,7 @@ telegram:
   # Alert via telegram? Note: also supersedes chain-specific settings
   enabled: no
   # API key ... talk to @BotFather
-  api_key: '5555555555:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+  api_key: "5555555555:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
   # The group ID for the chat where messages will be sent. Google how to find this, will include better info later.
   channel: "-666666666"
 
@@ -50,10 +49,18 @@ slack:
   # The webhook can be added in the Slack app directory.
   webhook: https://hooks.slack.com/services/AAAAAAAAAAAAAAAAAAAAAAA/bbbbbbbbbbbbbbbbbbbbbbbb
 
+# Healthcheck settings (dead man's switch)
+healthcheck:
+  # Send pings to determine if the monitor is running?
+  enabled: no
+  # URL to send pings to.
+  ping_url: https://hc-ping.com/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+  # Rate in which pings are sent in seconds.
+  ping_rate: 60
+
 # The various chains to be monitored. Create a new entry for each chain. The name itself can be arbitrary, but a
 # user-friendly name is recommended.
 chains:
-
   # The user-friendly name that will be used for labels. Highly suggest wrapping in quotes.
   "Osmosis":
     # chain_id is validated for a match when connecting to an RPC endpoint, also used as a label in several places.
@@ -115,8 +122,8 @@ chains:
 
       # Slack settings
       slack:
-          enabled: yes
-          webhook: "" # uses default if blank
+        enabled: yes
+        webhook: "" # uses default if blank
 
     # This section covers our RPC providers. No LCD (aka REST) endpoints are used, only TM's RPC endpoints
     # Multiple hosts are encouraged, and will be tried sequentially until a working endpoint is discovered.

--- a/td2/run.go
+++ b/td2/run.go
@@ -94,6 +94,15 @@ func Run(configFile, stateFile, chainConfigDirectory string, password *string) e
 				}
 			}()
 
+			// tenderduty health checks:
+			if td.Healthcheck.Enabled {
+				go func() {
+					for {
+						td.pingHealthcheck()
+					}
+				}()
+			}
+
 			// websocket subscription and occasional validator info refreshes
 			for {
 				e := cc.newRpc()

--- a/td2/run.go
+++ b/td2/run.go
@@ -80,6 +80,11 @@ func Run(configFile, stateFile, chainConfigDirectory string, password *string) e
 		}()
 	}
 
+	// tenderduty health checks:
+	if td.Healthcheck.Enabled {
+		td.pingHealthcheck()
+	}
+
 	for k := range td.Chains {
 		cc := td.Chains[k]
 
@@ -93,15 +98,6 @@ func Run(configFile, stateFile, chainConfigDirectory string, password *string) e
 					cc.monitorHealth(td.ctx, name)
 				}
 			}()
-
-			// tenderduty health checks:
-			if td.Healthcheck.Enabled {
-				go func() {
-					for {
-						td.pingHealthcheck()
-					}
-				}()
-			}
 
 			// websocket subscription and occasional validator info refreshes
 			for {

--- a/td2/types.go
+++ b/td2/types.go
@@ -64,6 +64,8 @@ type Config struct {
 	Telegram TeleConfig `yaml:"telegram"`
 	// Slack webhook information
 	Slack SlackConfig `yaml:"slack"`
+	// Healthcheck information
+	Healthcheck HealthcheckConfig `yaml:"healthcheck"`
 
 	chainsMux sync.RWMutex // prevents concurrent map access for Chains
 	// Chains has settings for each validator to monitor. The map's name does not need to match the chain-id.
@@ -220,6 +222,13 @@ type SlackConfig struct {
 	Enabled  bool     `yaml:"enabled"`
 	Webhook  string   `yaml:"webhook"`
 	Mentions []string `yaml:"mentions"`
+}
+
+// HealthcheckConfig holds the information needed to send pings to a healthcheck endpoint
+type HealthcheckConfig struct {
+	Enabled  bool          `yaml:"enabled"`
+	PingURL  string        `yaml:"ping_url"`
+	PingRate time.Duration `yaml:"ping_rate"`
 }
 
 // validateConfig is a non-exhaustive check for common problems with the configuration. Needs love.


### PR DESCRIPTION
I added a function that pings a user provided healthcheck URL at a user provided interval. This is useful to determine that the tenderduty application itself is live, and pagerduty notifications can be set if these healthcheck pings fail for a certain period of time.

I tested this locally and appears to function as intended.