### PR TITLE
Feature : Modify tenderduty dashboard status about tendermint bn254 pubkey type for union chain

### DIFF
--- a/example-config.yml
+++ b/example-config.yml
@@ -67,7 +67,7 @@ chains:
     chain_id: osmosis-1
     # Hooray, in v2 we derive the valcons from abci queries so you don't have to jump through hoops to figure out how
     # to convert ed25519 keys to the appropriate bech32 address.
-    # Use valcons address if using ICS
+    # Use valcons address if using ICS or tendermint/PubKeyBn254
     valoper_address: osmovaloper1xxxxxxx...
     # Should the monitor revert to using public API endpoints if all supplied RCP nodes fail?
     # This isn't always reliable, not all public nodes have websocket proxying setup correctly.

--- a/td2/rpc.go
+++ b/td2/rpc.go
@@ -272,7 +272,18 @@ func guessPublicEndpoint(u string) string {
 }
 
 func getStatusWithEndpoint(ctx context.Context, u string) (string, bool, error) {
-	queryPath := fmt.Sprintf("%s/status", u)
+	// Parse the URL
+	parsedURL, err := url.Parse(u)
+	if err != nil {
+		return "", false, err
+	}
+
+	// Check if the scheme is 'tcp' and modify to 'http'
+	if parsedURL.Scheme == "tcp" {
+		parsedURL.Scheme = "http"
+	}
+
+	queryPath := fmt.Sprintf("%s/status", parsedURL.String())
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, queryPath, nil)
 	if err != nil {
 		return "", false, err


### PR DESCRIPTION
## Purpose
Personally, so many validators who is operating chains in cosmos-sdk based chains want to use tenderduty for alerting their own validator nodes' uptime or something.

However, Its funtionality is not matched with chains which will be using BN254 types key such as Union Chain. 

Then, if you're a node operator in union testnet, you cannot see your node status like bottom.  

## Failure Examples
### dashboard & uptime
![image](https://github.com/blockpane/tenderduty/assets/43164634/4003c956-864e-4e5a-9826-a1265d9a0fc9)
### logs
![image](https://github.com/blockpane/tenderduty/assets/43164634/b5931b07-803e-4a2a-a3db-1397dec5d85c)

Because of it, I made a seond PR for tenderduty for modifying status and logs about tendermint. bn254 type and union chain.

I already knew it's not best way. But, It works! 

If you have a better way, I would welcome to modify this PR. Thanks.

