### PR TITLE
chore(prometheus.go): Fix typo when starting the process

### DIFF
--- a/td2/prometheus.go
+++ b/td2/prometheus.go
@@ -158,7 +158,7 @@ func prometheusExporter(ctx context.Context, updates chan *promUpdate) {
 
 	promMux := http.NewServeMux()
 
-	l("serving prometheus metrics at 0.0.0.0:%d/metrics", td.PrometheusListenPort)
+	l(fmt.Sprintf("📊 Serving prometheus metrics at 0.0.0.0:%d/metrics", td.PrometheusListenPort))
 	promMux.Handle("/metrics", promhttp.Handler())
 	promSrv := &http.Server{
 		Addr:              fmt.Sprintf(":%d", td.PrometheusListenPort),


### PR DESCRIPTION
This is fixing a typo when starting the process. The prometheus port number is not replaced by the value:
![image](https://github.com/user-attachments/assets/27382522-2a8e-48cb-80f3-3da62e5d8ae1)

After fixing the typo:
![image](https://github.com/user-attachments/assets/de0f8388-ffc3-45fc-935f-81ac5383e059)
