### PR TITLE
fix duplicate metrics without moniker

### DIFF
--- a/td2/validator.go
+++ b/td2/validator.go
@@ -74,10 +74,16 @@ func (cc *ChainConfig) GetValInfo(first bool) (err error) {
 	// Fetch info from /cosmos.staking.v1beta1.Query/Validator
 	// it's easier to ask people to provide valoper since it's readily available on
 	// explorers, so make it easy and lookup the consensus key for them.
-	cc.valInfo.Conspub, cc.valInfo.Moniker, cc.valInfo.Jailed, cc.valInfo.Bonded, err = getVal(ctx, cc.client, cc.ValAddress)
+	conspub, moniker, jailed, bonded, err := getVal(ctx, cc.client, cc.ValAddress)
 	if err != nil {
 		return
 	}
+
+	cc.valInfo.Conspub = conspub
+	cc.valInfo.Moniker = moniker
+	cc.valInfo.Jailed = jailed
+	cc.valInfo.Bonded = bonded
+
 	if first && cc.valInfo.Bonded {
 		l(fmt.Sprintf("⚙️ found %s (%s) in validator set", cc.ValAddress, cc.valInfo.Moniker))
 	} else if first && !cc.valInfo.Bonded {


### PR DESCRIPTION
**Problem**
At P-OPS Team, we notice that sometimes we have duplicate metrics on the same chain, the only difference is, one is with the moniker, the second one is with an empty moniker.
Example with nillion testnet:

> tenderduty_missed_blocks{chain_id="nillion-chain-testnet-1",moniker="pops",name="..."} 10
> tenderduty_missed_blocks{chain_id="nillion-chain-testnet-1",moniker="",name="..."} 10

**Symptoms**
If an error happened in getVal method, cc.valInfo.Moniker is set to empty string.

**Solution**
Update the moniker, conspub, jailed and bonded only if getVal doesn't return an error
